### PR TITLE
Removed php version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "license": "MIT",
     "description": "A Twig pack for Symfony projects",
     "require": {
-        "php": "^7.0",
         "symfony/twig-bundle": "*",
         "twig/twig": "^2.12|^3.0",
         "twig/extra-bundle": "^2.12|^3.0"


### PR DESCRIPTION
Removed php version constraint as requirements will be derived from
the packages and they seem to support php 8 already.

twig-extra has the strictest version constraint allowing ^7.1.3|^8.0 where twig and the twig-bundle are allowing  "php": ">=7.2.5"